### PR TITLE
Moved sandbox state clearing into dispose lifecycle method. This way …

### DIFF
--- a/lib/ui/shared/widgets/circuit_canvas/circuit_canvas.dart
+++ b/lib/ui/shared/widgets/circuit_canvas/circuit_canvas.dart
@@ -65,7 +65,6 @@ class _CircuitCanvasState extends ConsumerState<CircuitCanvas> {
 
   @override
   void dispose() {
-    print("Disposing widget");
     _transformationController.dispose();
     _sandboxState.reset();
     super.dispose();


### PR DESCRIPTION
…it only gets cleared when leaving the screen